### PR TITLE
Fix inventory consumption warning for missing resources

### DIFF
--- a/Assets/Scripts/InventoryManager.cs
+++ b/Assets/Scripts/InventoryManager.cs
@@ -42,13 +42,20 @@ public class InventoryManager : MonoBehaviour
 
     public bool ConsumeResource(string resourceId, int amount)
     {
-        if (resourceInventory.TryGetValue(resourceId, out int currentAmount) && currentAmount >= amount)
+        if (resourceInventory.TryGetValue(resourceId, out int currentAmount))
         {
-            resourceInventory[resourceId] -= amount;
-            Debug.Log($"Consumed {amount} of {resourceId}. Remaining: {resourceInventory[resourceId]}");
-            return true;
+            if (currentAmount >= amount)
+            {
+                resourceInventory[resourceId] -= amount;
+                Debug.Log($"Consumed {amount} of {resourceId}. Remaining: {resourceInventory[resourceId]}");
+                return true;
+            }
+
+            Debug.LogWarning($"Not enough {resourceId} to consume. Requested: {amount}, Available: {currentAmount}");
+            return false;
         }
-        Debug.LogWarning($"Not enough {resourceId} to consume. Requested: {amount}, Available: {currentAmount}");
+
+        Debug.LogWarning($"No {resourceId} available to consume. Requested: {amount}, Available: 0");
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- ensure InventoryManager.ConsumeResource handles missing resource entries safely
- provide clearer warning logs when resource counts are insufficient or absent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8b5dca748329b040c5054abfc86e